### PR TITLE
Cleaned up lifecycle hooks and removed construct hook

### DIFF
--- a/can-stache-define-element-test.js
+++ b/can-stache-define-element-test.js
@@ -1,11 +1,11 @@
-var QUnit = require("steal-qunit");
-var StacheDefineElement = require("./can-stache-define-element");
-var observe = require("can-observe");
+const QUnit = require("steal-qunit");
+const StacheDefineElement = require("./can-stache-define-element");
+const observe = require("can-observe");
 
 QUnit.module("can-stache-define-element");
 
 QUnit.test("basics", function(assert) {
-	var fixture = document.querySelector("#qunit-fixture");
+	const fixture = document.querySelector("#qunit-fixture");
 
 	class Person extends observe.Object {
 		get full() {
@@ -44,13 +44,13 @@ QUnit.test("basics", function(assert) {
 		<p>{{this.name.full}}</p>
 	`;
 	customElements.define("basic-app", Basic);
-	var el = document.createElement("basic-app");
+	const el = document.createElement("basic-app");
 	fixture.appendChild(el);
 
-	var inputs = document.querySelectorAll("input");
-	var firstNameInput = inputs[0];
-	var lastNameInput = inputs[1];
-	var fullNameP = document.querySelectorAll("p")[2];
+	const inputs = document.querySelectorAll("input");
+	const firstNameInput = inputs[0];
+	const lastNameInput = inputs[1];
+	const fullNameP = document.querySelectorAll("p")[2];
 
 	assert.equal(firstNameInput.value, "Kevin", "firstName input has correct default value");
 	assert.equal(lastNameInput.value, "McCallister", "lastName input has correct default value");

--- a/can-stache-define-element.js
+++ b/can-stache-define-element.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var mixinLifecycleMethods = require("./src/mixin-lifecycle-methods");
-var mixinDefineProperty = require("can-define-class/extend-with-define-property");
-var mixinStacheView = require("./src/mixin-stache-view");
-var mixinViewModelSymbol = require("./src/mixin-viewmodel-symbol");
+const mixinLifecycleMethods = require("./src/mixin-lifecycle-methods");
+const mixinDefineClass = require("./src/mixin-define-class");
+const mixinStacheView = require("./src/mixin-stache-view");
+const mixinViewModelSymbol = require("./src/mixin-viewmodel-symbol");
 
 function DeriveElement(BaseElement = HTMLElement) {
 	return class StacheDefineElement extends
@@ -11,9 +11,10 @@ function DeriveElement(BaseElement = HTMLElement) {
 	mixinViewModelSymbol(
 		// mix in stache renderer from `static view` property
 		mixinStacheView(
-			// add create getters/setters from `static define` property
-			mixinDefineProperty(
+			// add getters/setters from `static define` property
+			mixinDefineClass(
 				// add lifecycle hooks to BaseElement
+				// this needs to happen before other mixins that use these hooks
 				mixinLifecycleMethods(BaseElement)
 			)
 		)

--- a/src/mixin-define-class-test.js
+++ b/src/mixin-define-class-test.js
@@ -1,0 +1,9 @@
+const QUnit = require("steal-qunit");
+const mixinDefineClass = require("./mixin-define-class");
+
+QUnit.test("basics", function(assert) {
+	class DefineElement extends mixinDefineClass(HTMLElement) {}
+	customElements.define("define-element", DefineElement);
+	const el = new DefineElement();
+	assert.ok(el instanceof DefineElement);
+});

--- a/src/mixin-define-class.js
+++ b/src/mixin-define-class.js
@@ -1,0 +1,3 @@
+const mixinDefineClass = require("can-define-class/extend-with-define-property");
+
+module.exports = mixinDefineClass;

--- a/src/mixin-lifecycle-methods-test.js
+++ b/src/mixin-lifecycle-methods-test.js
@@ -1,12 +1,11 @@
-var QUnit = require("steal-qunit");
-var mixinLifecycleMethods = require("./mixin-lifecycle-methods");
+const QUnit = require("steal-qunit");
+const mixinLifecycleMethods = require("./mixin-lifecycle-methods");
 
-var canSymbol = require("can-symbol");
-var lifecycleStatusSymbol = canSymbol.for("can.lifecycleStatus");
-var inSetupSymbol = Symbol.for("can.initializing");
+const lifecycleStatusSymbol = Symbol.for("can.lifecycleStatus");
+const inSetupSymbol = Symbol.for("can.initializing");
 
 function assertStatuses(assert, obj, expected) {
-	var lifecycleStatus = obj[lifecycleStatusSymbol];
+	const lifecycleStatus = obj[lifecycleStatusSymbol];
 
 	[
 		"initialized",
@@ -61,7 +60,7 @@ QUnit.test("connectedCallback calls hooks - initialize, render, connect", functi
 	}
 	customElements.define("connencted-callback-hook-el", Obj);
 
-	var obj = new Obj();
+	const obj = new Obj();
 	obj.connectedCallback();
 });
 
@@ -89,7 +88,7 @@ QUnit.test("disconnectedCallback calls hooks - disconnect", function(assert) {
 	}
 	customElements.define("disconnencted-callback-hook-el", Obj);
 
-	var obj = new Obj();
+	const obj = new Obj();
 	obj.connectedCallback();
 	assertStatuses(assert, obj, {
 		initialized: true,
@@ -101,12 +100,12 @@ QUnit.test("disconnectedCallback calls hooks - disconnect", function(assert) {
 });
 
 QUnit.test("lifecycle works with document.createElement", function(assert) {
-	var fixture = document.querySelector("#qunit-fixture");
+	const fixture = document.querySelector("#qunit-fixture");
 
 	class Obj extends mixinLifecycleMethods(HTMLElement) {}
 	customElements.define("created-el", Obj);
 
-	var el = document.createElement("created-el");
+	const el = document.createElement("created-el");
 	assertStatuses(assert, el, {
 		initialized: false,
 		rendered: false,
@@ -149,7 +148,7 @@ QUnit.test("events are not dispatched in initialize, are dispatched during rende
 	}
 	customElements.define("event-dispatch-el", Obj);
 
-	var obj = new Obj();
+	const obj = new Obj();
 	obj.connectedCallback();
 });
 
@@ -174,7 +173,7 @@ QUnit.test("events are not dispatched in initialize, are dispatched during rende
 	}
 	customElements.define("event-dispatch-el-manual", Obj);
 
-	var obj = new Obj();
+	const obj = new Obj();
 	obj.initialize();
 	obj.render();
 	obj.connect();
@@ -201,7 +200,7 @@ QUnit.test("initialize, render, and connect are only called the first time conne
 	}
 	customElements.define("connencted-twice-el", Obj);
 
-	var obj = new Obj();
+	const obj = new Obj();
 	obj.connectedCallback();
 	obj.connectedCallback();
 });
@@ -222,6 +221,6 @@ QUnit.test("render calls initialize if it was not called", function(assert) {
 	}
 	customElements.define("render-calls-initialize-el", Obj);
 
-	var obj = new Obj();
+	const obj = new Obj();
 	obj.render();
 });

--- a/src/mixin-lifecycle-methods.js
+++ b/src/mixin-lifecycle-methods.js
@@ -1,44 +1,79 @@
 "use strict";
 
-var canSymbol = require("can-symbol");
-
-var lifecycleStatusSymbol = canSymbol.for("can.lifecycleStatus");
-
-function addLifecycleStatusSymbol(instance) {
-	Object.defineProperty(instance, lifecycleStatusSymbol, {
-		value: {
-			constructed: false,
-			initialized: false,
-			rendered: false,
-			connected: false
-		},
-		enumerable: false
-	});
-}
-
-function callLifecycleMethod(instance, methodName, statusName, status = true) {
-	if (typeof instance[methodName] === "function") {
-		instance[methodName]();
-	}
-	instance[lifecycleStatusSymbol][statusName] = status;
-}
+var lifecycleStatusSymbol = Symbol.for("can.lifecycleStatus");
+var inSetupSymbol = Symbol.for("can.initializing");
 
 module.exports = function mixinLifecycleMethods(BaseElement = HTMLElement) {
-	return class LifeCycleElement extends BaseElement {
+	return class LifecycleElement extends BaseElement {
 		constructor() {
 			super();
-			addLifecycleStatusSymbol(this);
-			callLifecycleMethod(this, "construct", "constructed");
+			// add inSetup symbol to prevent events being dispatched
+			Object.defineProperty(this, inSetupSymbol, {
+				configurable: true,
+				enumerable: false,
+				value: true,
+				writable: true
+			});
+
+			// add lifecycle status symbol
+			Object.defineProperty(this, lifecycleStatusSymbol, {
+				value: {
+					constructed: false,
+					initialized: false,
+					rendered: false,
+					connected: false
+				},
+				enumerable: false
+			});
 		}
 
+		// custom element lifecycle methods
 		connectedCallback() {
-			callLifecycleMethod(this, "initialize", "initialized");
-			callLifecycleMethod(this, "render", "rendered");
-			callLifecycleMethod(this, "connect", "connected");
+			var lifecycleStatus = this[lifecycleStatusSymbol];
+
+			if (!lifecycleStatus.initialized) {
+				this.initialize();
+			}
+
+			if (!lifecycleStatus.rendered) {
+				this.render();
+			}
+
+			if (!lifecycleStatus.connected) {
+				this.connect();
+			}
 		}
 
 		disconnectedCallback() {
-			callLifecycleMethod(this, "disconnect", "connected", false);
+			this.disconnect();
+		}
+
+		// custom lifecycle methods
+		construct() {
+			this[lifecycleStatusSymbol].constructed = true;
+		}
+
+		initialize() {
+			this[lifecycleStatusSymbol].initialized = true;
+			this[inSetupSymbol] = false;
+		}
+
+		render() {
+			var lifecycleStatus = this[lifecycleStatusSymbol];
+
+			if (!lifecycleStatus.initialized) {
+				this.initialize();
+			}
+
+			lifecycleStatus.rendered = true;
+		}
+
+		connect() {
+			this[lifecycleStatusSymbol].connected = true;
+		}
+
+		disconnect() {
+			this[lifecycleStatusSymbol].connected = false;
 		}
 	};
 };

--- a/src/mixin-lifecycle-methods.js
+++ b/src/mixin-lifecycle-methods.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var lifecycleStatusSymbol = Symbol.for("can.lifecycleStatus");
-var inSetupSymbol = Symbol.for("can.initializing");
+const lifecycleStatusSymbol = Symbol.for("can.lifecycleStatus");
+const inSetupSymbol = Symbol.for("can.initializing");
 
 module.exports = function mixinLifecycleMethods(BaseElement = HTMLElement) {
 	return class LifecycleElement extends BaseElement {
@@ -29,7 +29,7 @@ module.exports = function mixinLifecycleMethods(BaseElement = HTMLElement) {
 
 		// custom element lifecycle methods
 		connectedCallback() {
-			var lifecycleStatus = this[lifecycleStatusSymbol];
+			const lifecycleStatus = this[lifecycleStatusSymbol];
 
 			if (!lifecycleStatus.initialized) {
 				this.initialize();
@@ -59,7 +59,7 @@ module.exports = function mixinLifecycleMethods(BaseElement = HTMLElement) {
 		}
 
 		render() {
-			var lifecycleStatus = this[lifecycleStatusSymbol];
+			const lifecycleStatus = this[lifecycleStatusSymbol];
 
 			if (!lifecycleStatus.initialized) {
 				this.initialize();

--- a/src/mixin-stache-view-test.js
+++ b/src/mixin-stache-view-test.js
@@ -1,7 +1,7 @@
-var QUnit = require("steal-qunit");
-var mixinStacheView = require("./mixin-stache-view");
+const QUnit = require("steal-qunit");
+const mixinStacheView = require("./mixin-stache-view");
 
-var browserSupportsShadowDOM = typeof document.body.attachShadow === "function";
+const browserSupportsShadowDOM = typeof document.body.attachShadow === "function";
 
 QUnit.module("can-stache-define-element - mixin-stache-view");
 
@@ -17,7 +17,7 @@ QUnit.test("basics", function(assert) {
 	App.view = "Hello {{greeting}}";
 	customElements.define("stache-app", App);
 
-	var app = new App();
+	const app = new App();
 
 	assert.equal(typeof app.render, "function", "mixin adds a render method on class instances");
 	app.render();
@@ -39,7 +39,7 @@ if (browserSupportsShadowDOM) {
 		App.view = "Hello {{greeting}}";
 		customElements.define("stache-shadow-dom-app", App);
 
-		var app = new App();
+		const app = new App();
 
 		assert.equal(typeof app.render, "function", "mixin adds a render method on class instances");
 		app.render();

--- a/src/mixin-stache-view.js
+++ b/src/mixin-stache-view.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var stache = require("can-stache");
+const stache = require("can-stache");
 
 // make bindings work
 require("can-stache-bindings");
@@ -8,11 +8,10 @@ require("can-stache-bindings");
 module.exports = function mixinStacheView(Base = HTMLElement) {
 	return class StacheClass extends Base {
 		render() {
-			// stache render
-			var staticView = this.constructor.view;
-			var renderer = stache(staticView);
-			var frag = renderer(this);
-			var viewRoot = this.viewRoot || this;
+			const staticView = this.constructor.view;
+			const renderer = stache(staticView/* NODELIST */);
+			const frag = renderer(this);
+			const viewRoot = this.viewRoot || this;
 			viewRoot.appendChild( frag );
 		}
 	};

--- a/src/mixin-viewmodel-symbol-test.js
+++ b/src/mixin-viewmodel-symbol-test.js
@@ -1,13 +1,12 @@
-var QUnit = require("steal-qunit");
-var mixinViewModelSymbol = require("./mixin-viewmodel-symbol");
-var canSymbol = require("can-symbol");
-var viewModelSymbol = canSymbol.for("can.viewModel");
+const QUnit = require("steal-qunit");
+const mixinViewModelSymbol = require("./mixin-viewmodel-symbol");
+const viewModelSymbol = Symbol.for("can.viewModel");
 
 QUnit.module("can-stache-define-element - mixin-viewmodel-symbol");
 
 QUnit.test("basics", function(assert) {
 	class App extends mixinViewModelSymbol(class A {}) {}
 
-	var app = new App();
+	const app = new App();
 	assert.equal(app[viewModelSymbol], app, "instances get assigned viewModel Symbol");
 });

--- a/src/mixin-viewmodel-symbol.js
+++ b/src/mixin-viewmodel-symbol.js
@@ -1,8 +1,7 @@
 "use strict";
 
-var defineLazyValue = require("can-define-lazy-value");
-var canSymbol = require("can-symbol");
-var viewModelSymbol = canSymbol.for("can.viewModel");
+const defineLazyValue = require("can-define-lazy-value");
+const viewModelSymbol = Symbol.for("can.viewModel");
 
 module.exports = function mixinViewModelSymbol(BaseClass = HTMLElement) {
 	class ViewModelClass extends BaseClass {}

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 import "../can-stache-define-element-test";
+import "../src/mixin-define-class-test";
+import "../src/mixin-lifecycle-methods-test";
 import "../src/mixin-stache-view-test";
 import "../src/mixin-viewmodel-symbol-test";
-import "../src/mixin-lifecycle-methods-test";


### PR DESCRIPTION
closes https://github.com/canjs/can-stache-define-element/issues/8.