### PR TITLE
Allow StacheDefineElement to be used with import/export transpilation

### DIFF
--- a/src/can-stache-define-element.js
+++ b/src/can-stache-define-element.js
@@ -11,7 +11,7 @@ const initializeSymbol = Symbol.for("can.initialize");
 const teardownHandlersSymbol = Symbol.for("can.teardownHandlers");
 
 function DeriveElement(BaseElement = HTMLElement) {
-	return class StacheDefineElement extends
+	class StacheDefineElement extends
 	// add lifecycle methods
 	// this needs to happen after other mixins that implement these methods
 	// so that this.<lifecycleMethod> is the actual lifecycle method which
@@ -40,7 +40,17 @@ function DeriveElement(BaseElement = HTMLElement) {
 				el[teardownHandlersSymbol].push(teardownBindings);
 			}
 		}
-	};
+	}
+
+	function StacheDefineElementConstructorFunction() {
+		const self = Reflect.construct(StacheDefineElement, arguments, this.constructor);
+		return self;
+	}
+
+	StacheDefineElementConstructorFunction.prototype = Object.create(StacheDefineElement.prototype);
+	StacheDefineElementConstructorFunction.prototype.constructor = StacheDefineElementConstructorFunction;
+
+	return StacheDefineElementConstructorFunction;
 }
 
 module.exports = DeriveElement();

--- a/src/import-export-steal-test.js
+++ b/src/import-export-steal-test.js
@@ -1,0 +1,21 @@
+import QUnit from "steal-qunit";
+import StacheDefineElement from "./can-stache-define-element";
+import browserSupports from "../test/browser-supports";
+
+QUnit.module("can-stache-define-element - import/export syntax in steal");
+
+if (browserSupports.customElements) {
+	QUnit.test("Works when import/export syntax is transpiled by steal to ES5 constructor functions", function(assert) {
+		const tag = "import-export-steal";
+		class MyElement extends StacheDefineElement {
+			static get view() {
+				return "Hello world";
+			}
+		}
+
+		customElements.define(tag, MyElement);
+		let el = document.createElement(tag);
+		el.connect();
+		assert.equal(el.textContent, "Hello world", "rendered successfully");
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -3,3 +3,4 @@ import "../src/mixin-define-test";
 import "../src/mixin-lifecycle-methods-test";
 import "../src/mixin-stache-view-test";
 import "../src/mixin-viewmodel-symbol-test";
+import "../src/import-export-steal-test";


### PR DESCRIPTION
This allows StacheDefineElement to be used with import/export syntax in
loaders/bundlers that transpile to ES5, like steal.

ES2015 class constructors cannot be called with `.call`, but that's how
Babel 6 transpiles classes to constructor functions. The trick is to
insert a constructor function so that the ES2015 classes are not called
with `.call`.

Ideally this code could go somewhere like can-reflect where it could be
used in other projects.

Fixes #5 