### PR TITLE
Prevent DOM event warning from calling getter

### DIFF
--- a/src/can-stache-define-element-test.js
+++ b/src/can-stache-define-element-test.js
@@ -276,7 +276,12 @@ if (browserSupports.customElements) {
 	dev.devOnlyTest("Warns when a property matches an event name", function(assert) {
 		class ClickPropEl extends StacheDefineElement {
 			static get define() {
-				return { click: String };
+				return {
+					click: String,
+					get other() {
+						throw new Error('Don\'t get me');
+					}
+				};
 			}
 		}
 		customElements.define("click-prop-should-warn", ClickPropEl);

--- a/src/mixin-define.js
+++ b/src/mixin-define.js
@@ -27,7 +27,7 @@ module.exports = function mixinDefine(Base = HTMLElement) {
 		//!steal-remove-start
 		if(process.env.NODE_ENV !== 'production') {
 			let defines = typeof Type.define === "object" ? Type.define : {};
-			canReflect.eachKey(defines, function(value, key) {
+			Object.keys(defines).forEach(function(key) {
 				if("on" + key in Type.prototype) {
 					canLogDev.warn(`${canReflect.getName(Type)}: The defined property [${key}] matches the name of a DOM event. This property could update unexpectedly. Consider renaming.`);
 				}


### PR DESCRIPTION
Using `canReflect.eachKey` gets the value of the key which therefore
calls getters, which we don't want to happen. So this switches to using
Object.keys() which will not call into values.