### PR TITLE
4 set property from attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
+    "can-observable-bindings": "^1.0.0-pre.1",
     "can-reflect": "^1.17.11",
     "can-test-helpers": "^1.1.4",
     "can-type": "<2.0.0",

--- a/src/can-stache-element.js
+++ b/src/can-stache-element.js
@@ -5,6 +5,7 @@ const mixinProps = require("./mixin-props");
 const mixinStacheView = require("./mixin-stache-view");
 const mixinViewModelSymbol = require("./mixin-viewmodel-symbol");
 const mixinBindings = require("./mixin-bindings");
+const mixinInitializeBindings = require("./mixin-initialize-bindings");
 
 const canStacheBindings = require("can-stache-bindings");
 
@@ -20,12 +21,15 @@ function DeriveElement(BaseElement = HTMLElement) {
 	mixinLifecycleMethods(
 		// mixin .bindings() method and behavior
 		mixinBindings(
-			// mix in viewModel symbol used by can-stache-bindings
-			mixinViewModelSymbol(
-				// mix in stache renderer from `static view` property
-				mixinStacheView(
-					// add getters/setters from `static props` property
-					mixinProps(BaseElement)
+			// Initialize the bindings
+			mixinInitializeBindings(
+				// mix in viewModel symbol used by can-stache-bindings
+				mixinViewModelSymbol(
+					// mix in stache renderer from `static view` property
+					mixinStacheView(
+						// add getters/setters from `static props` property
+						mixinProps(BaseElement)
+					)
 				)
 			)
 		)

--- a/src/can-stache-element.js
+++ b/src/can-stache-element.js
@@ -6,6 +6,7 @@ const mixinStacheView = require("./mixin-stache-view");
 const mixinViewModelSymbol = require("./mixin-viewmodel-symbol");
 const mixinBindings = require("./mixin-bindings");
 const mixinInitializeBindings = require("./mixin-initialize-bindings");
+const mixinBindingProp = require("./mixin-binding-prop");
 
 const canStacheBindings = require("can-stache-bindings");
 
@@ -21,14 +22,17 @@ function DeriveElement(BaseElement = HTMLElement) {
 	mixinLifecycleMethods(
 		// mixin .bindings() method and behavior
 		mixinBindings(
-			// Initialize the bindings
-			mixinInitializeBindings(
-				// mix in viewModel symbol used by can-stache-bindings
-				mixinViewModelSymbol(
-					// mix in stache renderer from `static view` property
-					mixinStacheView(
-						// add getters/setters from `static props` property
-						mixinProps(BaseElement)
+			// Find all prop definitions and extract `{ bind: () => {} }` for binding initialization
+			mixinBindingProp(
+				// Initialize the bindings
+				mixinInitializeBindings(
+					// mix in viewModel symbol used by can-stache-bindings
+					mixinViewModelSymbol(
+						// mix in stache renderer from `static view` property
+						mixinStacheView(
+							// add getters/setters from `static props` property
+							mixinProps(BaseElement)
+						)
 					)
 				)
 			)

--- a/src/mixin-binding-prop-test.js
+++ b/src/mixin-binding-prop-test.js
@@ -1,0 +1,48 @@
+const QUnit = require("steal-qunit");
+const StacheElement = require("./can-stache-element");
+const value = require("can-value");
+const Bind = require("can-bind");
+const type = require("can-type");
+
+const testHelpers = require("../test/helpers");
+const browserSupports = testHelpers.browserSupports;
+
+let fixture;
+QUnit.module("can-stache-element - mixin-binding-prop", {
+	beforeEach() {
+		fixture = document.querySelector("#qunit-fixture");
+	}
+});
+
+if (browserSupports.customElements) {
+	QUnit.test("basics work", function(assert) {
+		class BasicBindingsElement extends StacheElement {
+			static get view() {
+				return `<h1>{{name}}</h1>`;
+			}
+
+			static get props() {
+				return {
+					name: {
+						type: type.maybeConvert(String),
+						bind: function (propertyName) {
+							return function (instance) {
+								return new Bind({
+									parent: value.from(instance.getAttribute(propertyName)),
+									child: value.to(instance, propertyName),
+									queue: "domUI"
+								});
+							};
+						}
+					}
+				};
+			}
+		}
+		customElements.define("binding-attribute", BasicBindingsElement);
+
+		fixture.innerHTML = "<binding-attribute name='Matt'></binding-attribute>";
+		const el = document.querySelector('binding-attribute');
+
+		assert.equal(el.name, 'Matt', 'We have set the property from the attribute');
+	});
+}

--- a/src/mixin-binding-prop.js
+++ b/src/mixin-binding-prop.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const metaSymbol = Symbol.for("can.meta");
+const { mixins } = require("can-observable-mixin");
+
+const bindingMap = new Map();
+
+module.exports = function mixinBindingProps(Base = HTMLElement) {
+	return class BindingPropsClass extends Base {
+		constructor() {
+			super();
+
+			if(this[metaSymbol] === undefined) {
+				this[metaSymbol] = {};
+			}
+
+			mixins.finalizeClass(this.constructor);
+			
+			if (this._define && this._define.definitions) {
+				Object.keys(this._define.definitions).forEach(propName => {
+					const definition = this._define.definitions[propName];
+					if (typeof definition.bind === 'function') {
+						const bindFn = definition.bind(propName);
+						bindingMap.set(propName, bindFn);
+					}
+				});
+			}
+		}
+		initialize(props) {
+			if (bindingMap) {
+				if (this[metaSymbol]._bindings === undefined) {
+					this[metaSymbol]._bindings = [];
+				}
+				bindingMap.forEach((createBind, propName) => {
+					const binding = createBind(this);
+
+					this[metaSymbol]._bindings.push({
+						binding,
+						siblingBindingData: {
+							parent: {
+								source: "scope",
+								exports: true
+							},
+							child: {
+								source: "viewModel",
+								exports: false,
+								name: propName
+							},
+							bindingAttributeName: propName
+						}
+					});
+				});
+			}
+
+			if (super.initialize) {
+				super.initialize(props);
+			}
+		}
+	};
+};

--- a/src/mixin-binding-prop.js
+++ b/src/mixin-binding-prop.js
@@ -43,7 +43,7 @@ module.exports = function mixinBindingProps(Base = HTMLElement) {
 							},
 							child: {
 								source: "viewModel",
-								exports: false,
+								exports: true,
 								name: propName
 							},
 							bindingAttributeName: propName

--- a/src/mixin-binding-prop.js
+++ b/src/mixin-binding-prop.js
@@ -13,6 +13,9 @@ module.exports = function mixinBindingProps(Base = HTMLElement) {
 			if(this[metaSymbol] === undefined) {
 				this[metaSymbol] = {};
 			}
+			if(this[metaSymbol]._uninitializedBindings === undefined) {
+				this[metaSymbol]._uninitializedBindings = {};
+			}
 
 			mixins.finalizeClass(this.constructor);
 			
@@ -21,7 +24,7 @@ module.exports = function mixinBindingProps(Base = HTMLElement) {
 					const definition = this._define.definitions[propName];
 					if (typeof definition.bind === 'function') {
 						const bindFn = definition.bind(propName);
-						bindingMap.set(propName, bindFn);
+						this[metaSymbol]._uninitializedBindings[propName] = bindFn;
 					}
 				});
 			}
@@ -31,8 +34,8 @@ module.exports = function mixinBindingProps(Base = HTMLElement) {
 				if (this[metaSymbol]._bindings === undefined) {
 					this[metaSymbol]._bindings = [];
 				}
-				bindingMap.forEach((createBind, propName) => {
-					const binding = createBind(this);
+				Object.keys(this[metaSymbol]._uninitializedBindings).forEach(propName => {
+					const binding = this[metaSymbol]._uninitializedBindings[propName](this);
 
 					this[metaSymbol]._bindings.push({
 						binding,

--- a/src/mixin-initialize-bindings-test.js
+++ b/src/mixin-initialize-bindings-test.js
@@ -1,0 +1,36 @@
+const QUnit = require("steal-qunit");
+const mixinInitializeBindings = require("./mixin-initialize-bindings");
+
+QUnit.module("can-stache-element - mixin-initialize-bindings");
+
+QUnit.test("disconnect calls super disconnect", function(assert) {
+	assert.expect(1);
+
+	class Obj {
+		disconnect() {
+			assert.ok(true, "disconnect called");
+		}
+	}
+
+	const InitializeBindingObj = mixinInitializeBindings(Obj);
+
+	const obj = new InitializeBindingObj();
+	obj.disconnect();
+});
+
+QUnit.test("initialize calls super initialize", function(assert) {
+	assert.expect(1);
+	
+	const props = { name: "Matt" };
+	
+	class Obj {
+		initialize(_props) {
+			assert.equal(_props, props, "initialize called");
+		}
+	}
+
+	const InitializeBindingObj = mixinInitializeBindings(Obj);
+
+	const obj = new InitializeBindingObj();
+	obj.initialize(props);
+});

--- a/src/mixin-initialize-bindings.js
+++ b/src/mixin-initialize-bindings.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const stacheBindings = require("can-stache-bindings");
+
+const lifecycleStatusSymbol = Symbol.for("can.lifecycleStatus");
+const metaSymbol = Symbol.for("can.meta");
+
+module.exports = function mixinBindings(Base = HTMLElement) {
+	return class InitializeBindingsClass extends Base {
+		initialize(props) {
+			var bindings = this[metaSymbol] && this[metaSymbol]._bindings;
+
+			if (bindings) {
+				const bindingContext = {
+					element: this
+				};
+				// Initialize the viewModel.  Make sure you
+				// save it so the observables can access it.
+				var initializeData = stacheBindings.behaviors.initializeViewModel(bindings, props, (properties) => {
+					super.initialize(properties);
+					return this;
+				}, bindingContext);
+	
+				this[metaSymbol]._connectedBindingsTeardown = function() {
+					for (var attrName in initializeData.onTeardowns) {
+						initializeData.onTeardowns[attrName]();
+					}
+				};
+			} else {
+				if (super.initialize) {
+					super.initialize(props);
+				}
+			}
+		}
+		disconnect() {
+			if(this[metaSymbol] && this[metaSymbol]._connectedBindingsTeardown) {
+				this[metaSymbol]._connectedBindingsTeardown();
+				this[metaSymbol]._connectedBindingsTeardown = null;
+				this[lifecycleStatusSymbol] = {
+					initialized: false,
+					rendered: false,
+					connected: false,
+					disconnected: true
+				};
+			}
+			if (super.disconnect) {
+				super.disconnect();
+			}
+		}
+	};
+};

--- a/test/test.js
+++ b/test/test.js
@@ -6,3 +6,4 @@ import "../src/mixin-viewmodel-symbol-test";
 import "../src/import-export-steal-test";
 import "../src/mixin-bindings-test";
 import "../src/mixin-initialize-bindings-test";
+import "../src/mixin-binding-prop-test";

--- a/test/test.js
+++ b/test/test.js
@@ -5,3 +5,4 @@ import "../src/mixin-stache-view-test";
 import "../src/mixin-viewmodel-symbol-test";
 import "../src/import-export-steal-test";
 import "../src/mixin-bindings-test";
+import "../src/mixin-initialize-bindings-test";


### PR DESCRIPTION
Currently a WIP to implement attributes setting properties.

This has the split `bindings-mixin` and the mixin to get the bind function from the property definition. I created a simple test for now to check that this works as thought. 

Will close https://github.com/canjs/can-stache-element/issues/4