### PR TITLE
Prevents duplicate bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-env": "^7.4.5",
     "can-reflect": "^1.17.11",
     "can-test-helpers": "^1.1.4",
-    "can-type": "^0.1.3",
+    "can-type": "^0.2.0",
     "can-value": "^1.1.1",
     "can-view-callbacks": "^4.4.0",
     "can-view-scope": "^4.13.1",

--- a/src/can-stache-element-test.js
+++ b/src/can-stache-element-test.js
@@ -291,4 +291,31 @@ if (browserSupports.customElements) {
 		assert.equal(undo(), 1, "Warned for the 'click' prop");
 	});
 
+	QUnit.test("bindings run once (#72)", function(assert) {
+
+		class CreateBindingsOnce extends StacheElement {
+			static get props(){
+				return {
+					value: Number
+				}
+			}
+		}
+
+		customElements.define('create-bindings-once', CreateBindingsOnce);
+
+		var calls = 0;
+
+		stache("<create-bindings-once value:from='this.read()'/>")({
+			read(){
+				calls++;
+				return 1;
+			}
+		});
+
+		assert.equal(calls,1, "only called once");
+
+
+
+	});
+
 }

--- a/src/can-stache-element-test.js
+++ b/src/can-stache-element-test.js
@@ -297,7 +297,7 @@ if (browserSupports.customElements) {
 			static get props(){
 				return {
 					value: Number
-				}
+				};
 			}
 		}
 

--- a/src/mixin-stache-view.js
+++ b/src/mixin-stache-view.js
@@ -12,7 +12,7 @@ const viewInsertSymbol = Symbol.for("can.viewInsert");
 stache.addBindings(stacheBindings);
 
 module.exports = function mixinStacheView(Base = HTMLElement) {
-	return class StacheClass extends Base {
+	class StacheClass extends Base {
 		render(props, renderOptions) {
 			if(super.render) {
 				super.render(props);
@@ -56,4 +56,6 @@ module.exports = function mixinStacheView(Base = HTMLElement) {
 			return this;
 		}
 	};
+	StacheClass.prototype[Symbol.for("can.preventDataBindings")] = true;
+	return StacheClass;
 };

--- a/src/mixin-stache-view.js
+++ b/src/mixin-stache-view.js
@@ -55,7 +55,7 @@ module.exports = function mixinStacheView(Base = HTMLElement) {
 		[viewInsertSymbol]() {
 			return this;
 		}
-	};
+	}
 	StacheClass.prototype[Symbol.for("can.preventDataBindings")] = true;
 	return StacheClass;
 };


### PR DESCRIPTION
For #72 ...

I made a [pre release](https://github.com/canjs/can-stache-bindings/releases/tag/v5.0.0-pre.6) of can-stache-bindings that does not setup bindings if `can.preventDataBindings` symbol is on an element and returns true.

Then I added this symbol to `StacheClass.prototype`.

I added the test to `can-stache-element`.    The test could be added to `mixin-stache-view-test`.  However, I wanted this fix in.  

The test itself sees if `read` is called multiple times:

```
stache("<create-bindings-once value:from='this.read()'/>")({
			read(){
				calls++;
				return 1;
			}
		});
```