### PR TITLE
can-template support

### DIFF
--- a/src/can-stache-element-test.js
+++ b/src/can-stache-element-test.js
@@ -400,4 +400,44 @@ if (browserSupports.customElements) {
 
 	});
 
+	QUnit.test("can-template called outside stache works (#77)",function(assert){
+		class CanGetTemplatesInCode extends StacheElement {
+			static get view() {
+				return `{{ this.bar() }}`;
+			}
+			static get props() {
+				return {
+					inner: "INNER"
+				};
+			}
+
+			bar() {
+				return this.foo({ passed: "PASSED" });
+			}
+		}
+		customElements.define("can-get-templates-in-code", CanGetTemplatesInCode);
+
+		var template = stache("outer.stache",
+			`{{ let letScope="LETSCOPE" }}
+			<can-get-templates-in-code>
+			<can-template name="foo">
+				<div class="outer">{{ this.outer }}</div>
+				<div class="let-scope">{{ letScope }}</div>
+				<div class="passed">{{ passed }}</div>
+			</can-template>
+			</can-get-templates-in-code>`);
+
+		var frag = template({
+			outer: "OUTER"
+		});
+
+		assert.equal(frag.firstElementChild.querySelector(".outer").innerHTML, "OUTER", "Access OUTER scope");
+
+		assert.equal(frag.firstElementChild.querySelector(".let-scope").innerHTML, "LETSCOPE", "Access let scope scope");
+
+		assert.equal(frag.firstElementChild.querySelector(".passed").innerHTML, "PASSED", "Access passed scope");
+
+
+	});
+
 }

--- a/src/can-stache-element-test.js
+++ b/src/can-stache-element-test.js
@@ -318,4 +318,40 @@ if (browserSupports.customElements) {
 
 	});
 
+	QUnit.test("can-template support (#77)",function(assert){
+
+		class CanGetTemplates extends StacheElement {
+			static get view(){
+				return stache("can-get-templates.stache",
+					"{{this.foo( passed='PASSED' )}}");
+			}
+			static get props(){
+				return {inner: "INNER"};
+			}
+		}
+
+		customElements.define('can-get-templates', CanGetTemplates);
+
+		var template = stache("outer.stache",
+			"{{let letScope='LETSCOPE'}}"+
+			"<can-get-templates>"+
+			"<can-template name='foo'>"+
+				"<div class='outer'>{{this.outer}}</div>"+
+				"<div class='let-scope'>{{letScope}}</div>"+
+				"<div class='passed'>{{passed}}</div>"+
+			"</can-template>"+
+			"</can-get-templates>");
+
+		var frag = template({
+			outer: "OUTER"
+		});
+
+		assert.equal(frag.firstElementChild.querySelector(".outer").innerHTML, "OUTER", "Access OUTER scope");
+
+		assert.equal(frag.firstElementChild.querySelector(".let-scope").innerHTML, "LETSCOPE", "Access let scope scope");
+
+		assert.equal(frag.firstElementChild.querySelector(".passed").innerHTML, "PASSED", "Access passed scope");
+
+	});
+
 }

--- a/src/can-stache-element.js
+++ b/src/can-stache-element.js
@@ -31,8 +31,8 @@ function addContext(rawRenderer, tagData) {
 		if(rendererWasCalledWithData(data)) {
 			return rawRenderer(tagData.scope.addLetContext(data._context));
 		} else {
-			// if it was called normal, just add the data
-			return rawRenderer(tagData.scope.add(data));
+			// if it was called programmatically (not in stache), just add the data
+			return rawRenderer(tagData.scope.addLetContext(data));
 		}
 	}
 	// Marking as a view will add the template scope ... but it should

--- a/src/can-stache-element.js
+++ b/src/can-stache-element.js
@@ -14,6 +14,33 @@ const { createConstructorFunction } = require("can-observable-mixin");
 
 const initializeSymbol = Symbol.for("can.initialize");
 const teardownHandlersSymbol = Symbol.for("can.teardownHandlers");
+const isViewSymbol = Symbol.for("can.isView");
+const Scope = require("can-view-scope");
+
+// Calling a renderer like {{foo()}} gets the template scope
+// added no matter what. This checks for that condition.
+// https://github.com/canjs/can-stache/issues/719
+function rendererWasCalledWithData(scope) {
+	return scope instanceof Scope &&
+		scope._parent &&
+		scope._parent._context instanceof Scope.TemplateContext;
+}
+
+function addContext(rawRenderer, tagData) {
+	function renderer(data) {
+		if(rendererWasCalledWithData(data)) {
+			return rawRenderer(tagData.scope.addLetContext(data._context));
+		} else {
+			// if it was called normal, just add the data
+			return rawRenderer(tagData.scope.add(data));
+		}
+	}
+	// Marking as a view will add the template scope ... but it should
+	// already be present in `tagData.scope`.
+	// However, I mark this as a renderer because that is what it is.
+	renderer[isViewSymbol] = true;
+	return renderer;
+}
 
 function DeriveElement(BaseElement = HTMLElement) {
 	class StacheElement extends
@@ -47,10 +74,16 @@ function DeriveElement(BaseElement = HTMLElement) {
 				el,
 				tagData,
 				function makeViewModel(initialViewmodelData) {
+					for(let prop in tagData.templates) {
+						// It's ok to modify the argument. The argument is created
+						// just for what gets passed into creating the VM.
+						initialViewmodelData[prop] = addContext(tagData.templates[prop], tagData);
+					}
 					el.render(initialViewmodelData);
 					return el;
 				}
 			);
+
 
 			if (el[teardownHandlersSymbol]) {
 				el[teardownHandlersSymbol].push(teardownBindings);


### PR DESCRIPTION
for #77, this adds `<can-template>` support. StacheElement `<can-template>` differs from Component `<can-template>` in one major respect (I think): 

> StacheElement passes variables like `{{renderer(myVar='value')}}` in a `LetScope`, Component passes variables like `<can-slot myVar:from='value'>` as a new scope.

__UPDATE__ The previous statement is not true. Component also passes as a let scope: https://github.com/canjs/can-component/blob/571a719bb68ea92f32be2e0e1133dfd255183d57/can-component.js#L91

However, `{{renderer( myVar='value' ) }}` would normally call the renderer with a new context, I sorta hacked around this behavior.

I created an issue around this area of `CallExpression` here: https://github.com/canjs/can-stache/issues/719