### PR TITLE
Use 'can' module in example instead of 'everything'

### DIFF
--- a/docs/can-stache-element.md
+++ b/docs/can-stache-element.md
@@ -26,7 +26,7 @@
   ```html
   <count-er></count-er>
   <script type="module">
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
   class Counter extends StacheElement {
     static view = `
       Count: <span>{{ this.count }}</span>
@@ -75,7 +75,7 @@ In order to create a basic custom element with `StacheElement`, create a class t
 ```html
 <count-er></count-er>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
 }
 customElements.define("count-er", Counter);
@@ -95,7 +95,7 @@ To create a [can-stache] view for the element, add a [can-stache-element/static.
 ```html
 <count-er></count-er>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
   static view = `
     Count: <span>{{ this.count }}</span>
@@ -119,7 +119,7 @@ To add property definitions, add a [can-stache-element/static.props static props
 ```html
 <count-er></count-er>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
   static view = `
     Count: <span>{{ this.count }}</span>
@@ -142,7 +142,7 @@ Methods (as well as getters and setters) can be added to the class body as well:
 ```html
 <count-er></count-er>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
   static view = `
     Count: <span>{{ this.count }}</span>
@@ -169,7 +169,7 @@ If needed, [can-stache-element/lifecycle-hooks.connected] and [can-stache-elemen
 <button id="add">Add Timer</button>
 <button id="remove">Remove Timer</button>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class Timer extends StacheElement {
   static view = `
@@ -293,7 +293,7 @@ within the `StacheElement`'s [can-stache-element/static.view]. For example,
 <my-app></my-app>
 
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class HelloWorld extends StacheElement {
   static view = `
@@ -329,7 +329,7 @@ with a [can-stache/expressions/hash]. The following passes the message:
 <my-app></my-app>
 
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class HelloWorld extends StacheElement {
   static view = `
@@ -364,7 +364,7 @@ entire custom element:
 <my-app></my-app>
 
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class HelloWorld extends StacheElement {
   static view = `
@@ -402,7 +402,7 @@ In the view:
 <my-app></my-app>
 
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class HelloWorld extends StacheElement {
   static view = `
@@ -437,7 +437,7 @@ As a default props value:
 <my-app></my-app>
 
 <script type="module">
-import { StacheElement, stache } from "can/everything";
+import { StacheElement, stache } from "can";
 
 class HelloWorld extends StacheElement {
   static view = `
@@ -472,7 +472,7 @@ its HTML like following:
 <my-app></my-app>
 
 <script type="module">
-import { StacheElement, stache } from "can/everything";
+import { StacheElement, stache } from "can";
 
 class HelloWorld extends StacheElement {
   static view = `
@@ -535,7 +535,7 @@ To test an element's properties and methods, call the [can-stache-element/lifecy
 
 
 ```js
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
   static view = `
     Count: <span>{{ this.count }}</span>
@@ -565,7 +565,7 @@ counter.count === 21; // -> true
 To test an element's view, call the [can-stache-element/lifecycle-methods.render] method with any initial property values:
 
 ```js
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
   static view = `
     Count: <span>{{ this.count }}</span>
@@ -595,7 +595,7 @@ counter.firstElementChild.innerHTML === "21"; // -> true
 To test the functionality of the `connected` or `disconnected` hooks, you can call the [can-stache-element/lifecycle-methods.connect] or [can-stache-element/lifecycle-methods.disconnect] method.
 
 ```js
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class Timer extends StacheElement {
   static view = `

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -8,7 +8,7 @@
   Calling `connect` will [can-stache-element/lifecycle-methods.initialize] and [can-stache-element/lifecycle-methods.render] an element and call its [can-stache-element/lifecycle-hooks.connected] hook. Normally this is called by the [can-stache-element/lifecycle-methods.connectedCallback], but can be called manually for testing:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	  static view = `

--- a/docs/connected.md
+++ b/docs/connected.md
@@ -10,7 +10,7 @@
   ```html
   <time-er></time-er>
   <script type="module">
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class Timer extends StacheElement {
 	  static view = `

--- a/docs/connectedCallback.md
+++ b/docs/connectedCallback.md
@@ -10,7 +10,7 @@
   The `connectedCallback` can also be called manually to trigger these things. For example, the following defines a `greeting` property, uses it in the `view`, and also programmatically adds a `<p>` element in the `connected` hook:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	static view = `

--- a/docs/disconnect.md
+++ b/docs/disconnect.md
@@ -8,7 +8,7 @@
   Calling `disconnect` will clean up an element's event handlers and call its [can-stache-element/lifecycle-hooks.disconnected disconnected hook]. Normally this is called by the [can-stache-element/lifecycle-methods.disconnectedCallback], but can be called manually for testing:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   const logs = [];
 

--- a/docs/disconnected.md
+++ b/docs/disconnected.md
@@ -10,7 +10,7 @@
    The following example uses `disconnected` to make an HTTP POST request when the element is removed from the page:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	  disconnected() {

--- a/docs/disconnectedCallback.md
+++ b/docs/disconnectedCallback.md
@@ -10,7 +10,7 @@
   The `disconnectedCallback` can also be called manually to trigger these things:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	  connected() {

--- a/docs/initialize.md
+++ b/docs/initialize.md
@@ -8,7 +8,7 @@
   Calling `initialize` will set up property definitions and set initial property values. Normally this is called by the [can-stache-element/lifecycle-methods.connectedCallback], but can be called manually for testing:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	  static view = `

--- a/docs/props.md
+++ b/docs/props.md
@@ -10,7 +10,7 @@
   To add property definitions, add a `static` class field like shown below.
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class TodoItem extends StacheElement {
 	  static props = {
@@ -70,7 +70,7 @@ These are discussed below and the full set of options can be found in the [can-o
 The following example...
 
 ```js
-import { StacheElement, type } from "can/everything";
+import { StacheElement, type } from "can";
 
 class Person extends StacheElement {
 	static view = `
@@ -109,7 +109,7 @@ The following example shows a few examples of declarative properties:
 ```html
 <per-son></per-son>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class Person extends StacheElement {
 	static view = `
@@ -149,7 +149,7 @@ In the following example, an error is thrown because the `<to-do>` element is in
 ```html
 <to-do></to-do>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class Todo extends StacheElement {
 	static props = {

--- a/docs/render.md
+++ b/docs/render.md
@@ -8,7 +8,7 @@
   Calling `render` will [can-stache-element/lifecycle-methods.initialize] an element and render its [can-stache-element/static.view] into its `innerHTML`. Normally this is called by the [can-stache-element/lifecycle-methods.connectedCallback], but can be called manually for testing:
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
 
   class MyElement extends StacheElement {
 	  static view = `

--- a/docs/view.md
+++ b/docs/view.md
@@ -10,7 +10,7 @@
   ```html
   <count-er></count-er>
   <script type="module">
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
   class Counter extends StacheElement {
   	static view = `
   		<p>Count: <span>1</span></p>
@@ -28,7 +28,7 @@
   For browsers that do not support class fields (and applications not using a transpiler), properties can be defined using a `static` getter like shown below.
 
   ```js
-  import { StacheElement } from "can/everything";
+  import { StacheElement } from "can";
   class Counter extends StacheElement {
   	static get view() {
   		return `
@@ -43,7 +43,7 @@
   A function can be passed as the view property. This is useful for loading views in their own files and loading them with [steal-stache] or similar.
 
   ```js
-  import { StacheElement, stache } from "can/everything";
+  import { StacheElement, stache } from "can";
 
   const renderer = stache(`<p>Count: <span>1</span></p>`);
 
@@ -79,7 +79,7 @@ There are three things to understand about an element's view:
 The view is rendered with `this` as the element instance. The following prints the `age` property of the element.
 
 ```js
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 
 class Person extends StacheElement {
 	static view = `
@@ -148,7 +148,7 @@ StacheElement handles rendering the view at the right time. In normal applicatio
 ```html
 <count-er></count-er>
 <script type="module">
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
 	static view = `
 		<p>Count: <span>1</span></p>
@@ -169,7 +169,7 @@ customElements.define("count-er", Counter);
 For testing purposes, the [can-stache-element/lifecycle-methods.render] method can be called to manually render the view. This means that the view can be tested without putting the element in the page, which greatly improves the performance of tests.
 
 ```js
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 class Counter extends StacheElement {
 	static view = `
 		<p>Count: <span>1</span></p>
@@ -197,7 +197,7 @@ The [guides/setup] guide has details on how to import stache views directly. For
 the following example uses `import view from "./app.stache";`:
 
 ```js
-import { StacheElement } from "can/everything";
+import { StacheElement } from "can";
 import view from "./app.stache";
 
 class MyApp extends StacheElement {


### PR DESCRIPTION
Update the docs to use `import { StacheElement } from "can";`  instead of `import { StacheElement } from "can/everything";` .